### PR TITLE
Pass the correct Synthea age parameters

### DIFF
--- a/src/components/Process.vue
+++ b/src/components/Process.vue
@@ -245,8 +245,7 @@
         url += '&state=' + this.state
         url += '&gender=' + this.gender
         url += '&city=' + this.city
-        url += '&minAge=' + this.minAge
-        url += '&maxAge=' + this.maxAge
+        url += '&ageRange=' + this.minAge + '-' + this.maxAge
         url += '&seed=' + this.seed
         const self = this
         self.view.processResults = ''


### PR DESCRIPTION
Ensure that the age values for Synthea are not passed as max and min
age but instead as an "ageRange" parameter to match what is expected.